### PR TITLE
Add support for install using npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+scripted.log
+server/jsdepend/test-resources/node-with-bad-data

--- a/bin/launchnode
+++ b/bin/launchnode
@@ -1,4 +1,4 @@
 # Node launch script
-DIRNAME=`dirname "$0"`
+DIRNAME=`dirname $(readlink -f "$0")`
 cd $DIRNAME/../server
 node scripted.js

--- a/bin/scr
+++ b/bin/scr
@@ -10,7 +10,7 @@
 pid=`ps axu | grep "node scripted.js" | grep -v grep | awk '{print $2}'`
 # echo "pid = " $pid
 
-DIRNAME=`dirname "$0"`
+DIRNAME=`dirname $(readlink -f "$0")`
 
 if [ ! -z "$pid" ]
 then

--- a/bin/scripted
+++ b/bin/scripted
@@ -10,7 +10,7 @@
 pid=`ps axu | grep "node scripted.js" | grep -v grep | awk '{print $2}'`
 # echo "pid = " $pid
 
-DIRNAME=`dirname "$0"`
+DIRNAME=`dirname $(readlink -f "$0")`
 
 if [ ! -z "$pid" ]
 then

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "scripted",
+  "version": "0.2.0",
+  "description": "A fast and lightweight browser based code editor",
+  "keywords": [
+    "javascript",
+    "browser",
+    "code",
+    "editor"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/scripted-editor/scripted.git"
+  },
+  "bugs": {
+    "url": "http://github.com/scripted-editor/scripted/issues"
+  },
+  "contributors": [
+    "Andy Clement <andrew.clement@gmail.com>",
+    "Andrew Eisenberg <aeisenberg@vmware.com>",
+    "Alain Kalker <a.c.kalker@gmail.com>",
+    "Kris De Volder <kdvolder@vmware.com>"
+  ],
+  "bin": {
+    "scr": "./bin/scr",
+    "scripted": "./bin/scripted"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "EPL",
+  "readmeFilename": "README.md"
+}


### PR DESCRIPTION
Adding initial support for installation using npm, as requested in issue #3.

This should have no impact on using scripted in other settings not managed by npm.
The most important change is using `readlink -f` to make the `scr`, `xcripted` and `launchnode` scripts aware of their absolute path, so they can be safely symlinked into npm's PREFIX/bin directory and continue to function normally.
Added a template `package.json` file with enough information to build a package.

Any suggestions are very welcome.
