### PR TITLE
Mark 'console', "exports", 'module', and 'process' as global

### DIFF
--- a/.scripted
+++ b/.scripted
@@ -96,6 +96,7 @@
 */
 {
 	"jslint" : {
-		"global" : ["define", "require", "$", "window"]
+		"global" : ["console", "define", "exports", "module", "process",
+					"require", "$", "window"]
 	}
 }


### PR DESCRIPTION
Mark these as global, so they will not be flagged as errors in the editor.
They are frequently used in Node.js projects.
