### PR TITLE
Make Browser Configurable via SCRBROWSER

### DIFF
--- a/bin/scr.bat
+++ b/bin/scr.bat
@@ -35,4 +35,4 @@ echo Starting scripted.js... >> scripted.log
 
 start /MIN cmd /c node %rootdir%\server\scripted.js^>^>scripted.log
 
-start "" "http://localhost:7261/editor/%patharg%"
+start "" %SCRBROWSER% "http://localhost:7261/editor/%patharg%"


### PR DESCRIPTION
Allows the user to specify an environment variable `%SCRBROWSER%` which points to the browser they want to use for scripted editor.
