### PR TITLE
Provide a filename-only placeholder for exec

### DIFF
--- a/client/scripts/scripted/exec/param-resolver.js
+++ b/client/scripts/scripted/exec/param-resolver.js
@@ -83,9 +83,23 @@ function forEditor(editor) {
 		return editor.getFilePath();				
 	});
 	
-	def("${filename}", function() {
+	// Returns 'hello.js' from '/path/project/sub/helloworld.js'
+	def("${fileName}", function() {
 		var p = editor.getFilePath();
 		return p.substring(p.lastIndexOf('/')+1);
+	});
+	
+	// Returns 'sub/hello.js' from '/path/project/sub/helloworld.js'
+	def("${filePath}", function() {
+		var p = editor.getFilePath();
+		return p.substring((window.fsroot || getDir()).length+1);
+	});
+	
+	// Returns 'hello' from '/path/project/sub/helloworld.js'
+	def("${fileBase}", function() {
+		var p = editor.getFilePath();
+		p = p.substring(p.lastIndexOf('/')+1);
+		return p.substring(0, p.lastIndexOf('.'));
 	});
 	
 	def("${dir}", getDir);


### PR DESCRIPTION
Say we want to run unit-tests when the current file `foo.js` is saved. Our tests require that the following command is run:
`node tests\test-foo.js`

In order for this to work we need a `${filename}` placeholder which returns only `foo.js` and not the full path (as `${file}` currently does).

``` javascript
"exec": {
  "afterSave": {
    "*.js": "node tests/test-${filename}"
  }
}
```
