### PR TITLE
Decouple UI from localhost

### DIFF
--- a/client/scripts/scripted/editor/editorPane.js
+++ b/client/scripts/scripted/editor/editorPane.js
@@ -21,7 +21,7 @@ define(["scripted/keybindings/keybinder", "scripted/editor/scriptedEditor", "scr
 function(mKeybinder, mEditor, mPaneFactory, mNavHistory, mKeyBinding, mPageState, mOpenResourceDialog, mOutlineDialog,
 	mLookInFilesDialog, mOsUtils) {
 
-	var FS_LIST_URL = "http://localhost:7261/fs_list/";
+	var FS_LIST_URL = "/fs_list/";
 	// FIXADE copied from navhistory
 	var EDITOR_TARGET = {
 		main : "main",

--- a/client/scripts/scripted/editor/scriptedEditor.js
+++ b/client/scripts/scripted/editor/scriptedEditor.js
@@ -404,8 +404,8 @@ define([
 					// As described here: http://www.w3.org/TR/html4/interact/forms.html - may need to add some content
 					// type settings to dispositions, for funky charsets
 					var boundary = Math.random().toString().substr(2);
-					//var url = 'http://localhost:7261/put?file=' + window.location.search.substr(1);
-					var url = 'http://localhost:7261/put?file=' + filePath;
+					//var url = '/put?file=' + window.location.search.substr(1);
+					var url = '/put?file=' + filePath;
 					//				console.log("url is "+url);
 					//				console.log("Saving file, length is "+text.length);
 					xhr.open("POST", url, true);
@@ -563,7 +563,7 @@ define([
 		
 		var xhrobj = new XMLHttpRequest();
 		try {
-			var url = 'http://localhost:7261/get?file=' + filePath;
+			var url = '/get?file=' + filePath;
 			//console.log("Getting contents for " + url);
 			xhrobj.open("GET", url, false); // synchronous xhr
 			

--- a/client/scripts/scripted/fileapi.js
+++ b/client/scripts/scripted/fileapi.js
@@ -44,7 +44,7 @@ define(['servlets/stub-maker'], function (mStubMaker) {
 		//TODO: XMLHttpRequest may not be defined in all environments.
 	var xhrobj = new XMLHttpRequest();
 		try {
-			var url = 'http://localhost:7261/get?file='+handle;
+			var url = '/get?file='+handle;
 			// console.log("url is "+url);
 			xhrobj.open("GET",url,true);
 			xhrobj.send();
@@ -69,7 +69,7 @@ define(['servlets/stub-maker'], function (mStubMaker) {
 	function getContentsSync(handle) {
 		//TODO: XMLHttpRequest may not be defined in all environments.
 		var xhrobj = new XMLHttpRequest();
-		var url = 'http://localhost:7261/get?file='+handle;
+		var url = '/get?file='+handle;
 		// console.log("url is "+url);
 		xhrobj.open("GET",url,false);
 		xhrobj.send();
@@ -87,7 +87,7 @@ define(['servlets/stub-maker'], function (mStubMaker) {
 		//TODO: XMLHttpRequest may not be defined in all environments.
 		var xhrobj = new XMLHttpRequest();
 		try {
-			var url = 'http://localhost:7261/ls?file='+handle;
+			var url = '/ls?file='+handle;
 			// console.log("ls url is "+url);
 			xhrobj.open("GET",url,true);
 			xhrobj.send();

--- a/client/scripts/scripted/navigator/explorer-table.js
+++ b/client/scripts/scripted/navigator/explorer-table.js
@@ -77,7 +77,7 @@ define('scripted/navigator/explorer-table', ['require', 'dojo', 'scripted/naviga
 			if (parentItem.ChildrenLocation) {
 				var xhrobj = new XMLHttpRequest();
 				try {
-					var url = 'http://localhost:7261/fs_list/' + parentItem.ChildrenLocation;
+					var url = '/fs_list/' + parentItem.ChildrenLocation;
 //					scriptedLogger.debug("url is " + url, "EXPLORER_TABLE");
 					xhrobj.open("GET", url, true);
 					xhrobj.onreadystatechange = function() {
@@ -590,7 +590,7 @@ if (mExtensionCommands) {
 
 			var xhrobj = new XMLHttpRequest();
 			try {
-				var url = 'http://localhost:7261/fs_list/' + path;
+				var url = '/fs_list/' + path;
 //				scriptedLogger.debug("url is " + url, "EXPLORER_TABLE");
 				xhrobj.open("GET", url, true);
 				xhrobj.onreadystatechange = function() {

--- a/client/scripts/scripted/utils/navHistory.js
+++ b/client/scripts/scripted/utils/navHistory.js
@@ -27,7 +27,7 @@ function(mSidePanelManager, mPaneFactory, mPageState, mOsUtils, editorUtils) {
 		tab : "tab"
 	};
 	var LINE_SCROLL_OFFSET = 5;
-	var GET_URL = "http://localhost:7261/get?file=";
+	var GET_URL = "/get?file=";
 	
 	// define as forward reference
 	var navigate;

--- a/client/scripts/servlets/stub-maker.js
+++ b/client/scripts/servlets/stub-maker.js
@@ -52,7 +52,7 @@ define(['when'], function(when) {
 			});
 			var xhrobj = new XMLHttpRequest();
 			try {
-				var url = 'http://localhost:7261'+path+'?args='+ encodeURIComponent(args);
+				var url = path+'?args='+ encodeURIComponent(args);
 				// console.log("url is "+url);
 				xhrobj.onreadystatechange= function() {
 			        if(xhrobj.readyState === 4) { // 4 means content has finished loading, TODO use XMLHttpRequest.DONE
@@ -88,7 +88,7 @@ define(['when'], function(when) {
 				var xhrobj = new XMLHttpRequest();
 				try {
 					var args = JSON.stringify([handle]);
-					var url = 'http://localhost:7261'+path+'?args='+ encodeURIComponent(args);
+					var url = path+'?args='+ encodeURIComponent(args);
 					// console.log("url is "+url);
 					xhrobj.onreadystatechange= function() {
 				        if(xhrobj.readyState === 4) { // 4 means content has finished loading
@@ -115,7 +115,7 @@ define(['when'], function(when) {
 				var xhrobj = new XMLHttpRequest();
 				try {
 					var args = JSON.stringify([arg1, arg2]);
-					var url = 'http://localhost:7261'+path+'?args='+ encodeURIComponent(args);
+					var url = path+'?args='+ encodeURIComponent(args);
 					// console.log("url is "+url);
 					xhrobj.open("GET",url,true);
 					xhrobj.send();
@@ -138,7 +138,7 @@ define(['when'], function(when) {
 				var xhrobj = new XMLHttpRequest();
 				try {
 					var args = JSON.stringify([arg1]);
-					var url = 'http://localhost:7261'+path+'?args='+ encodeURIComponent(args);
+					var url = path+'?args='+ encodeURIComponent(args);
 					// console.log("url is "+url);
 					xhrobj.open("GET",url,true);
 					xhrobj.send();
@@ -161,7 +161,7 @@ define(['when'], function(when) {
 				var xhrobj = new XMLHttpRequest();
 				try {
 					var args = JSON.stringify([arg1, arg2]);
-					var url = 'http://localhost:7261'+path+'?args='+ encodeURIComponent(args);
+					var url = path+'?args='+ encodeURIComponent(args);
 					// console.log("url is "+url);
 					xhrobj.open("GET",url,true);
 					xhrobj.send();
@@ -184,7 +184,7 @@ define(['when'], function(when) {
 				var xhrobj = new XMLHttpRequest();
 				try {
 					var args = JSON.stringify([arg1, arg2, arg3]);
-					var url = 'http://localhost:7261'+path+'?args='+ encodeURIComponent(args);
+					var url = path+'?args='+ encodeURIComponent(args);
 					// console.log("url is "+url);
 					xhrobj.open("GET",url,true);
 					xhrobj.send();


### PR DESCRIPTION
The UI is currently hard coded to localhost:7261 in several places. This
makes it impossible to run scripted on any other host or port. Using
host-relative URLs will maintain the same origin as the original request.

This is a first step towards being able to run scripted on a remote
server.
