### PR TITLE
Allow exec 'env' to inherit from 'process.env'

### DIFF
--- a/server/servlets/exec-servlet.js
+++ b/server/servlets/exec-servlet.js
@@ -10,7 +10,7 @@
  * Contributors:
  *     Kris De Volder - initial API and implementation
  ******************************************************************************/
- 
+
 /*global console require*/
 
 var servlets = require('../servlets');
@@ -25,6 +25,15 @@ function exec(cmd, callback, errback) {
 
 	var options = cmd;
 	cmd = cmd.cmd;
+
+	// TODO use mixin, if scipted had one...
+	// options.env = mixin({}, options.env, process.env);
+	options.env = options.env || {};
+	for (var env in process.env) {
+		if (!(env in options.env)) {
+			options.env[env] = process.env[env];
+		}
+	}
 
 	/*var process = */cpExec(cmd, options, callback);
 }


### PR DESCRIPTION
When executing a command Node uses `process.env` by default. If the 'env'
option is specified, Node assumes that the complete environment is
provided.

As Scripted exec configurations are declarative, and it's practically
impossible to correctly configure an environment declaratively, Scripted
should mix the declared env vars into the 'process.env'.

For example, this is my .scripted config:

``` json
"exec": {
  "onKeys": {
    "cmd+b": {
      "cmd": "npm test",
      "cwd": "${projectDir}",
      "name": "Test Project",
      "env": {
        "BUSTER_TEST_OPT": "--color none --reporter specification"
      }
    }
  }
}
```

Before this patch, Node is unable to spawn the child process because the
environment is incomplete.  After this patch, it's able to run the command
with 'process.env' as the environment, augmented with 'BUSTER_TEST_OPT'.
