### PR TITLE
fixes #298 uses proper npm package for cujo.js "when"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,60 +1,64 @@
 {
-	"name": "scripted",
-	"version": "0.5.0",
-	"description": "A fast and lightweight browser based code editor",
-	"keywords": [ "javascript", "browser", "code", "editor" ],
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/scripted-editor/scripted.git"
-	},
-	"bugs": {
-		"url": "http://github.com/scripted-editor/scripted/issues"
-	},
-	"contributors": [
-		"Andy Clement <aclement@vmware.com>",
-		"Andrew Eisenberg <aeisenberg@vmware.com>",
-		"Kris De Volder <kdvolder@vmware.com>",
-		"Alain Kalker <a.c.kalker@gmail.com>",
-		"Nieraj Singh <nierajsingh@vmware.com>",
-		"Scott Andrews <andrewss@vmware.com>",
-		"Jeremy Grelle <jgrelle@vmware.com>",
-		"Brian Cavalier <bcavalier@vmware.com>",
-		"John Hann <jhann@vmware.com>",
-		"Tony Georgiev <tgeorgiev@vmware.com>",
-		"Loc Nguyen <nal_io@yahoo.com>"
-	],
-	"bin": {
-		"scr": "./bin/scr",
-		"scripted": "./bin/scripted"
-	},
-	"scripts": {
-		"start" : "node server/start-cloudfoundry.js",
-		"test": "node tests/server/run-all.js",
-		"postinstall": "cd client && bower install"
-	},
-	"dependencies": {
-        "amdefine": "0.0.2",
-		"enhanced-resolve": "0.4.5",
-        "formidable": "1.0.9",
-        "htmlparser": "1.7.6",
-        "json5": "0.1.0",
-        "node-static": "0.5.9",
-        "optimist": "0.3.5",
-        "rest": "0.8.4",
-		"serv": "https://github.com/aclement/serv/archive/master.tar.gz",
-        "sockjs": "0.3.1",
-        "websocket-multiplex": "https://github.com/kdvolder/websocket-multiplex/archive/master.tar.gz",
-        "when": "https://github.com/cujojs/when/archive/noisy-deferred-then.tar.gz",
-        "rest": "https://github.com/s2js/rest/archive/dev.tar.gz",
-        "express": "3.0.6",
-		"bower": "0.8.5",
-		"mime": "1.2.9",
-		"priorityqueuejs": "0.1.0"
-	},
-	"devDependencies": {
-		"fake-fs": "https://github.com/eldargab/node-fake-fs/archive/50f54e9551d9ece5578213564268021d4976db26.tar.gz",
-		"nodeunit": "0.7.4"
-	},
-	"license": "EPL",
-	"readmeFilename": "README.md"
+  "name": "scripted",
+  "version": "0.5.0",
+  "description": "A fast and lightweight browser based code editor",
+  "keywords": [
+    "javascript",
+    "browser",
+    "code",
+    "editor"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/scripted-editor/scripted.git"
+  },
+  "bugs": {
+    "url": "http://github.com/scripted-editor/scripted/issues"
+  },
+  "contributors": [
+    "Andy Clement <aclement@vmware.com>",
+    "Andrew Eisenberg <aeisenberg@vmware.com>",
+    "Kris De Volder <kdvolder@vmware.com>",
+    "Alain Kalker <a.c.kalker@gmail.com>",
+    "Nieraj Singh <nierajsingh@vmware.com>",
+    "Scott Andrews <andrewss@vmware.com>",
+    "Jeremy Grelle <jgrelle@vmware.com>",
+    "Brian Cavalier <bcavalier@vmware.com>",
+    "John Hann <jhann@vmware.com>",
+    "Tony Georgiev <tgeorgiev@vmware.com>",
+    "Loc Nguyen <nal_io@yahoo.com>"
+  ],
+  "bin": {
+    "scr": "./bin/scr",
+    "scripted": "./bin/scripted"
+  },
+  "scripts": {
+    "start": "node server/start-cloudfoundry.js",
+    "test": "node tests/server/run-all.js",
+    "postinstall": "cd client && bower install"
+  },
+  "dependencies": {
+    "amdefine": "0.0.2",
+    "enhanced-resolve": "0.4.5",
+    "formidable": "1.0.9",
+    "htmlparser": "1.7.6",
+    "json5": "0.1.0",
+    "node-static": "0.5.9",
+    "optimist": "0.3.5",
+    "rest": "https://github.com/s2js/rest/archive/dev.tar.gz",
+    "serv": "https://github.com/aclement/serv/archive/master.tar.gz",
+    "sockjs": "0.3.1",
+    "websocket-multiplex": "https://github.com/kdvolder/websocket-multiplex/archive/master.tar.gz",
+    "when": "~2.8.0",
+    "express": "3.0.6",
+    "bower": "0.8.5",
+    "mime": "1.2.9",
+    "priorityqueuejs": "0.1.0"
+  },
+  "devDependencies": {
+    "fake-fs": "https://github.com/eldargab/node-fake-fs/archive/50f54e9551d9ece5578213564268021d4976db26.tar.gz",
+    "nodeunit": "0.7.4"
+  },
+  "license": "EPL",
+  "readmeFilename": "README.md"
 }


### PR DESCRIPTION
The editor seems to work fine. But I have no idea if I broke something as there is no indication which version was used before. Tests seem to run fine until this error:

```
SockJS v0.3.1 bound to "/websockets"
Server port = 7261
Server has started.
http://localhost:7261/clientTests

events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: listen EADDRINUSE
    at errnoException (net.js:901:11)
    at Server._listen2 (net.js:1039:14)
    at listen (net.js:1061:10)
    at net.js:1135:9
    at dns.js:72:18
    at process._tickCallback (node.js:415:13)
npm ERR! weird error 8
npm ERR! not ok code 0

```

The file used mixed tabs and spaces and since I didn't find any style guidelines, I used my default 2 spaces indentation.
